### PR TITLE
Fix library name on unix (needs .so extension).

### DIFF
--- a/sodium.lisp
+++ b/sodium.lisp
@@ -12,7 +12,7 @@
   (unless (cffi:foreign-symbol-pointer "sodium_init")
     (define-foreign-library libsodium
       (:darwin (:or "libsodium.dylib"))
-      (:unix (:or "libsodium"))
+      (:unix (:or "libsodium.so"))
       (:windows (:or "libsodium-10.dll"
                      "libsodium.dll"))
       (t (:default "libsodium")))


### PR DESCRIPTION
Without the .so extension, lisp fails to load the library on unix systems. The :default designator will add it, but here it just tries to use 'libsodium' verbatim.
