### PR TITLE
Automatic interface generation

### DIFF
--- a/scripts/bindings.i
+++ b/scripts/bindings.i
@@ -1,3 +1,9 @@
+/* NOTE: This file is used to generate bindings only when the
+ * sodium.h header is present. If you are building against a
+ * non-ancient version (0.1 or later) of libsodium, this is not
+ * the file you want. See scripts/generate.sh and the generated
+ * scripts/bindings.gen.i file.
+ */
 %module bindings
 
 %feature("intern_function", "lispify");

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -27,8 +27,9 @@ if [ -f "$SODIUM_HEADERS/sodium.h" ]; then
 (in-package :sodium)
 %}
 
-# This is necessary to fix an ordering issue.
+# These are necessary to fix ordering issues.
 %include "sodium/export.h"
+%include "sodium/crypto_stream_chacha20.h"
 EOF
 	cat "$SODIUM_HEADERS/sodium.h" >> "$BINDING_FILE"
 	sed -i -e 's/# *include/%include/' "$BINDING_FILE"

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -43,6 +43,9 @@ swig "-I$SODIUM_HEADERS" -cffi -module bindings -noswig-lisp -o bindings.lisp "$
 ASN1_TYPE_CONSTRUCTED_VAL="`grep ASN1_TYPE_CONSTRUCTED bindings.lisp | head -1 | sed 's|.*#\.\((cl:ash[^)]\+)\).*|\1|' `"
 sed -i "s|(cl:logior \([0-9]\+\) ASN1_TYPE_CONSTRUCTED)|(cl:logior \1 $ASN1_TYPE_CONSTRUCTED_VAL)|g" bindings.lisp
 perl -i.bak -pe 's/^\(cl:defconstant /(define-string / if /"\)$/;' bindings.lisp
+# Fix integers with a length suffix. Only convert an integer followed by a space, end-of-line, or close-paren
+# to avoid accidentally clobbering some integer-looking value.
+sed -E -i -e 's/( -?[0-9]+)[UulL]( |\)|$)/\1\2/' bindings.lisp
 
 # ------------------------------------------------------------------------------
 # make our exports


### PR DESCRIPTION
This is maybe a bit controversial, so comments/complaints are welcome (the script changes are a little groady in particular, although they do work). This also generates a /lot/ more bindings than before; assuming this change is acceptable, should those new bindings be included in this branch?

There were two things that had to be fiddled with in order to get the generated bindings to be loadable with this; I expect that in general this represents a tradeoff of occasional fiddling when new things are added, vs not having to keep the list of headers up to date in the bindings file. This may or may not be a desirable tradeoff to make. Anyway:

Newer versions of libsodium ship with a single common header that includes
all the other headers in the library. SWIG can't process such a header
itself (it doesn't recurse into includes), but with a little preprocessing
we can construct an interface file on-the-fly that will process all of the
headers included by the common header. This should avoid future issues with
headers that are removed, and also eliminate the burden of having to update
the bindings file every time libsodium adds new algorithms.

Note that the existing binding file is left in place and used if the common
header isn't found, to support older versions. The common header also uses
an oddball '# include' directive at present, so we have to match spaces in
the include directive during preprocessing.